### PR TITLE
Update artemis-java-test-sandbox to Version 1.4.6

### DIFF
--- a/artemis-java-template/pom.xml
+++ b/artemis-java-template/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>de.tum.in.ase</groupId>
 			<artifactId>artemis-java-test-sandbox</artifactId>
-			<version>1.1.1</version>
+			<version>1.4.6</version>
 			<scope>test</scope>
 		</dependency>		    
         <dependency>


### PR DESCRIPTION
Just a dependency update of `artemis-java-test-sandbox`. Note that this was previously on version `1.1.1`, so quite an old release.

For details, see https://github.com/ls1intum/artemis-java-test-sandbox/compare/1.1.1...1.4.6